### PR TITLE
Boost versioned dependency on iotawattpy, add "version"

### DIFF
--- a/homeassistant/components/iotawatt/manifest.json
+++ b/homeassistant/components/iotawatt/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/iotawatt",
   "requirements": [
-    "iotawattpy==0.0.3"
+    "iotawattpy==0.0.4"
   ],
   "ssdp": [],
   "zeroconf": [],
@@ -12,5 +12,6 @@
   "dependencies": [],
   "codeowners": [
     "@gtdiehl"
-  ]
+  ],
+  "version": "0.0.20201217"
 }


### PR DESCRIPTION
to mitigate issues reported on https://community.home-assistant.io/t/custom-component-iotawatt-energy-monitor-integration/254110/21

but may be this repo is not the one to be used anyways?
